### PR TITLE
Add ability to copy a data folder

### DIFF
--- a/cbscript.py
+++ b/cbscript.py
@@ -131,6 +131,7 @@ class cbscript(object):
 		if os.path.exists(latest_log_filename):
 			self.latest_log_file = source_file(latest_log_filename)
 
+		world.write_data(parsed['data'])
 		world.write_functions(self.global_context.functions)
 		world.write_tags(self.global_context.clocks, self.global_context.block_tags, self.global_context.entity_tags, self.global_context.item_tags)
 		world.write_mcmeta(parsed['desc'])

--- a/cbscript.py
+++ b/cbscript.py
@@ -97,7 +97,7 @@ class cbscript(object):
 		if type != 'program':
 			self.log('Script does not contain a full program.')
 			return False
-			
+
 		self.global_context = global_context.global_context(self.namespace)
 		global_environment = environment(self.global_context)
 		global_environment.set_dollarid('namespace', self.namespace)
@@ -131,7 +131,6 @@ class cbscript(object):
 		if os.path.exists(latest_log_filename):
 			self.latest_log_file = source_file(latest_log_filename)
 
-		world.write_data(parsed['data'])
 		world.write_functions(self.global_context.functions)
 		world.write_tags(self.global_context.clocks, self.global_context.block_tags, self.global_context.entity_tags, self.global_context.item_tags)
 		world.write_mcmeta(parsed['desc'])
@@ -139,6 +138,7 @@ class cbscript(object):
 		world.write_advancements(self.global_context.advancements)
 		world.write_loot_tables(self.global_context.loot_tables)
 		world.write_predicates(self.global_context.predicates)
+		world.write_data(parsed['data'])
 		world.write_zip()
 		
 		self.dependencies = [source_file(d) for d in self.global_context.dependencies]

--- a/mcworld.py
+++ b/mcworld.py
@@ -22,19 +22,6 @@ class mcworld(object):
 		logfile = os.path.join(logsdir, 'latest.log')
 		
 		return logfile
-	
-	def write_data(self, data):
-		data_dir = 'data/'
-		if data is not None:
-			for subdir, dirs, files in os.walk(data):
-				for file in files:
-					data_copy_path = os.path.join(subdir, file)
-
-					data_raw_path = os.path.relpath(data_copy_path, data)
-					data_zip_path = os.path.join(data_dir, data_raw_path)
-					with open(data_copy_path, "rb") as file:
-						file_bytes = file.read()
-						self.zip.writestr(data_zip_path, file_bytes)
 
 	def write_functions(self, functions):
 		function_dir = f'data/{self.namespace}/functions/'
@@ -118,6 +105,21 @@ class mcworld(object):
 		
 		self.zip.writestr(mcmeta_file, json.dumps({'pack':{'pack_format':1, 'description':desc}}, indent=4))
 	
+	def write_data(self, data):
+		data_dir = 'data'
+		if data is not None:
+			for subdir, dirs, files in os.walk(data):
+				for file in files:
+					data_copy_path = os.path.join(subdir, file)
+
+					data_raw_path = os.path.relpath(data_copy_path, data)
+					data_zip_path = os.path.join(data_dir, data_raw_path)
+					if data_zip_path.replace(os.sep, '/') not in self.zip.namelist():
+						with open(data_copy_path, "rb") as file:
+							file_bytes = file.read()
+							self.zip.writestr(data_zip_path, file_bytes)
+						
+
 	def write_zip(self):
 		self.zip.close()
 	

--- a/mcworld.py
+++ b/mcworld.py
@@ -23,6 +23,19 @@ class mcworld(object):
 		
 		return logfile
 	
+	def write_data(self, data):
+		data_dir = 'data/'
+		if data is not None:
+			for subdir, dirs, files in os.walk(data):
+				for file in files:
+					data_copy_path = os.path.join(subdir, file)
+
+					data_raw_path = os.path.relpath(data_copy_path, data)
+					data_zip_path = os.path.join(data_dir, data_raw_path)
+					with open(data_copy_path, "rb") as file:
+						file_bytes = file.read()
+						self.zip.writestr(data_zip_path, file_bytes)
+
 	def write_functions(self, functions):
 		function_dir = f'data/{self.namespace}/functions/'
 		

--- a/scriptlex.py
+++ b/scriptlex.py
@@ -8,7 +8,7 @@ keywords = (
     'reset', 'clock', 'function', 'if', 'unless', 'then', 'do', 'else', 'switch', 'case', 'default',
     'return', 'while', 'macro', 'block', 'block_data', 'block_tag', 'entity_tag', 'item_tag', 'define', 'array', 'remove', 'success', 'result',
 	'shaped', 'recipe', 'keys', 'eyes', 'feet',	'advancement', 'loot_table', 'predicate',
-	'push', 'pop', 'true', 'false',
+	'push', 'pop', 'true', 'false', 'data'
 )
 
 tokens = keywords + (

--- a/scriptparse.py
+++ b/scriptparse.py
@@ -115,15 +115,16 @@ def p_parsed_expr(p):
 	
 #### Program
 def p_program(p):
-	'''program : optcomments dir string newlines optdesc file_params top_level_blocks'''
+	'''program : optcomments dir string newlines optdesc optdata file_params top_level_blocks'''
 	p[0] = {}
 	p[0]['dir'] = p[3]
 	p[0]['desc'] = p[5]
+	p[0]['data'] = p[6]
 
-	for param_name in p[6]:
-		p[0][param_name] = p[6][param_name]
+	for param_name in p[7]:
+		p[0][param_name] = p[7][param_name]
 	
-	p[0]['lines'] = p[7]
+	p[0]['lines'] = p[8]
 	
 ### Lib
 def p_lib(p):
@@ -161,7 +162,15 @@ def p_file_param(p):
 		raise SyntaxError(f'Unknown file parameter: "{p[1]}" at line {p.lineno(1)}')
 	
 	p[0] = (p[1], int(p[2]))
-	
+
+def p_optdata(p):
+	'''optdata : data string newlines
+			   | empty'''	
+	if len(p) < 4:
+		p[0] = None
+	else:
+		p[0] = p[2]
+
 #### Sections
 def p_section_commented(p):
 	'''section_commented : optcomments section'''


### PR DESCRIPTION
Some datapacks benefit from including structures and similar files. 

This PR adds the ability to define a `data` folder to directly copy into the compiled pack.
The folder should have the exact same directory structure as the `data` directory in a datapack.

The `data` key is optional, and placed after the `dir` and `desc`, before `scale`

Example:
```
dir "<World Dir>"
desc "Pack Description"
data "./pack_data"
scale 1000
```

```
./pack_data
-> namespace
----> structures
-------> structure.nbt
```

The files are copied after any other ones from the script are created, so that files with duplicate names can be ignored.
i.e. `function test()` in the cbscript will essentially override `test.mcfunction` in the same namespace in the data folder if it happens to be there.