### PR TITLE
Fixed a template literal issue

### DIFF
--- a/block_types/template_function_call_block.py
+++ b/block_types/template_function_call_block.py
@@ -42,7 +42,7 @@ class template_function_call_block(call_block_base):
 		
 		# Calculate function arguments
 		for i in range(len(args)):
-			assignto = scoreboard_var(f'Global', 'Param{i}')
+			assignto = scoreboard_var(f'Global', f'Param{i}')
 			arg_var = args[i].compile(func, assignto)
 			
 			assignto.copy_from(func, arg_var)


### PR DESCRIPTION
This issue is a bug I ran into, where the score in Minecraft would be named "Param{i}". Minecraft scoreboards do not support characters such as "{}", so this caused the datapack function file to break